### PR TITLE
Automate npm releases from version tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,193 @@
+name: Release
+
+on:
+  push:
+    tags:
+      # Stable releases: v1.2.3
+      - "v[0-9]+.[0-9]+.[0-9]+"
+      # Pre-releases: v1.2.3-rc.1, v1.2.3-beta.2, etc.
+      - "v[0-9]+.[0-9]+.[0-9]+-*"
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  verify-tag:
+    name: Verify release tag
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Verify release tag
+        run: node scripts/verify-release-tag.mjs "${{ github.ref_name }}"
+
+  quality-and-package:
+    name: Check, build, and package
+    runs-on: ubuntu-latest
+    needs: verify-tag
+    timeout-minutes: 15
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v6
+        with:
+          version: 11.17.0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Check formatting, lint, and types
+        run: pnpm check
+
+      - name: Build package
+        run: pnpm build
+
+      - name: Pack npm tarball
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          version="${RELEASE_TAG#v}"
+          tgz="release/npm/vite-plugin-oidc-auth-${version}.tgz"
+          mkdir -p release/npm
+          npm pack --pack-destination release/npm
+          if [ ! -f "${tgz}" ]; then
+            echo "No npm tarball found at ${tgz}" >&2
+            exit 1
+          fi
+
+      - name: Upload verified npm tarball
+        uses: actions/upload-artifact@v6
+        with:
+          name: npm-package
+          path: release/npm/*.tgz
+          if-no-files-found: error
+          retention-days: 7
+
+  publish-npm:
+    name: Publish to npmjs.com
+    runs-on: ubuntu-latest
+    needs: quality-and-package
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+
+      - name: Verify Node 24 and npm >= 11.5.1
+        shell: bash
+        run: |
+          set -euo pipefail
+          node_version="$(node --version)"
+          echo "node: ${node_version}"
+          case "${node_version}" in
+            v24.*) ;;
+            *) echo "Expected Node 24, got ${node_version}" >&2; exit 1 ;;
+          esac
+
+          npm_version="$(npm --version)"
+          echo "npm: ${npm_version}"
+          # Trusted publishing (OIDC) requires npm >= 11.5.1.
+          if [ "$(printf '%s\n11.5.1\n' "${npm_version}" | sort -V | head -n1)" != "11.5.1" ]; then
+            echo "Upgrading npm to satisfy trusted publishing (>= 11.5.1)"
+            npm install -g npm@latest
+            echo "npm: $(npm --version)"
+          fi
+
+      - name: Download verified npm tarball
+        uses: actions/download-artifact@v7
+        with:
+          name: npm-package
+          path: release/npm
+
+      - name: Publish npm tarball
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          name="vite-plugin-oidc-auth"
+          version="${RELEASE_TAG#v}"
+          tgz="release/npm/vite-plugin-oidc-auth-${version}.tgz"
+          if [ ! -f "${tgz}" ]; then
+            echo "No verified tarball found at ${tgz}" >&2
+            exit 1
+          fi
+          if npm view "${name}@${version}" version >/dev/null 2>&1; then
+            echo "Skipping ${name}@${version} (already published)"
+            exit 0
+          fi
+
+          dist_tag="latest"
+          if [[ "${version}" == *-* ]]; then
+            dist_tag="next"
+          fi
+          echo "Publishing ${tgz} as ${name}@${version} with dist-tag ${dist_tag}"
+          npm publish "${tgz}" --provenance --access public --tag "${dist_tag}"
+
+  github-release:
+    name: Create GitHub release
+    runs-on: ubuntu-latest
+    needs: publish-npm
+    permissions:
+      contents: write
+
+    steps:
+      - name: Download verified npm tarball
+        uses: actions/download-artifact@v7
+        with:
+          name: npm-package
+          path: release/npm
+
+      - name: Create release and attach npm tarball
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          version="${RELEASE_TAG#v}"
+          tgz="release/npm/vite-plugin-oidc-auth-${version}.tgz"
+          if [ ! -f "${tgz}" ]; then
+            echo "No verified tarball found at ${tgz}" >&2
+            exit 1
+          fi
+
+          if gh release view "${RELEASE_TAG}" >/dev/null 2>&1; then
+            echo "Release ${RELEASE_TAG} already exists; refreshing its npm tarball"
+            gh release upload "${RELEASE_TAG}" "${tgz}" --clobber
+            exit 0
+          fi
+
+          release_args=(--verify-tag --generate-notes)
+          if [[ "${version}" == *-* ]]; then
+            release_args+=(--prerelease)
+          fi
+          gh release create "${RELEASE_TAG}" "${tgz}" "${release_args[@]}"

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.0.6/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.4.8/schema.json",
 	"vcs": {
 		"enabled": false,
 		"clientKind": "git",
@@ -7,7 +7,7 @@
 	},
 	"files": {
 		"ignoreUnknown": false,
-		"includes": ["!**/dist/**"]
+		"includes": ["**", "!**/dist"]
 	},
 	"formatter": {
 		"enabled": true,

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
 	"version": "0.4.0",
 	"description": "A Vite plugin for OIDC authentication during development (dev mode only)",
 	"type": "module",
+	"packageManager": "pnpm@11.17.0",
 	"main": "./dist/index.js",
 	"module": "./dist/index.js",
 	"types": "./dist/index.d.ts",
@@ -18,7 +19,9 @@
 	],
 	"scripts": {
 		"build": "tsc",
+		"check": "biome check packages && tsc --noEmit",
 		"prepublishOnly": "npm run build",
+		"release:verify-tag": "node scripts/verify-release-tag.mjs",
 		"format": "biome format --write",
 		"lint": "biome lint --write"
 	},

--- a/packages/lib/config.ts
+++ b/packages/lib/config.ts
@@ -2,53 +2,53 @@ import dotenv from "dotenv";
 import type { OidcOptions, OidcPluginOptions } from "./types.js";
 
 function getEnv(key: string): string {
-  const value = process.env[key];
-  if (!value) {
-    throw new Error(
-      `[OIDC Auth] Environment variable ${key} is not set. This plugin requires OIDC configuration in development mode.`
-    );
-  }
-  return value;
+	const value = process.env[key];
+	if (!value) {
+		throw new Error(
+			`[OIDC Auth] Environment variable ${key} is not set. This plugin requires OIDC configuration in development mode.`,
+		);
+	}
+	return value;
 }
 
 export function getEnvOidcPluginOptions(envFilePath?: string): OidcOptions {
-  try {
-    if (envFilePath) {
-      dotenv.config({
-        path: envFilePath,
-      });
-    } else {
-      dotenv.config({
-        path: ".env",
-      });
-      dotenv.config({
-        path: ".env.local",
-        override: true,
-      });
-    }
-    return {
-      discoveryUrl: getEnv("OIDC_DISCOVERY_URL"),
-      clientId: getEnv("OIDC_CLIENT_ID"),
-      clientSecret: getEnv("OIDC_CLIENT_SECRET"),
-      redirectUri: getEnv("OIDC_REDIRECT_URI"),
-      scope: getEnv("OIDC_SCOPE"),
-    };
-  } catch (error) {
-    console.error(
-      "❌ [OIDC Auth] Failed to load OIDC configuration:",
-      error instanceof Error ? error.message : "Unknown error"
-    );
-    console.log(
-      "💡 [OIDC Auth] Make sure you have the required environment variables set in your .env file"
-    );
-    throw error;
-  }
+	try {
+		if (envFilePath) {
+			dotenv.config({
+				path: envFilePath,
+			});
+		} else {
+			dotenv.config({
+				path: ".env",
+			});
+			dotenv.config({
+				path: ".env.local",
+				override: true,
+			});
+		}
+		return {
+			discoveryUrl: getEnv("OIDC_DISCOVERY_URL"),
+			clientId: getEnv("OIDC_CLIENT_ID"),
+			clientSecret: getEnv("OIDC_CLIENT_SECRET"),
+			redirectUri: getEnv("OIDC_REDIRECT_URI"),
+			scope: getEnv("OIDC_SCOPE"),
+		};
+	} catch (error) {
+		console.error(
+			"❌ [OIDC Auth] Failed to load OIDC configuration:",
+			error instanceof Error ? error.message : "Unknown error",
+		);
+		console.log(
+			"💡 [OIDC Auth] Make sure you have the required environment variables set in your .env file",
+		);
+		throw error;
+	}
 }
 
 export function getDefaultOidcPluginOptions(): OidcPluginOptions {
-  return {
-    openBrowser: true,
-    cacheFile: ".oidc-cache.json",
-    serverTimeout: 30, // seconds
-  };
+	return {
+		openBrowser: true,
+		cacheFile: ".oidc-cache.json",
+		serverTimeout: 30, // seconds
+	};
 }

--- a/packages/lib/main.ts
+++ b/packages/lib/main.ts
@@ -1,252 +1,252 @@
 import {
-  createServer,
-  type IncomingMessage,
-  type ServerResponse,
+	createServer,
+	type IncomingMessage,
+	type ServerResponse,
 } from "node:http";
 import * as client from "openid-client";
 import type { Plugin, ViteDevServer } from "vite";
 
 import {
-  getDefaultOidcPluginOptions,
-  getEnvOidcPluginOptions,
+	getDefaultOidcPluginOptions,
+	getEnvOidcPluginOptions,
 } from "./config.js";
 import { createErrorPage, createSuccessPage } from "./templates.js";
 import type { CachedTokenData, OidcPluginOptions } from "./types.js";
 import { openBrowser, readCachedToken, writeCachedToken } from "./utils.js";
 
 function validateCachedToken(cacheFile: string): string | null {
-  const cachedData = readCachedToken(cacheFile);
-  if (!cachedData) {
-    return null;
-  }
+	const cachedData = readCachedToken(cacheFile);
+	if (!cachedData) {
+		return null;
+	}
 
-  const now = Date.now();
-  const bufferMs = 30 * 1000; // 30 seconds buffer
+	const now = Date.now();
+	const bufferMs = 30 * 1000; // 30 seconds buffer
 
-  if (now >= cachedData.expires_at - bufferMs) {
-    console.log("🔄 [OIDC Auth] Cached token has expired");
-    return null;
-  }
+	if (now >= cachedData.expires_at - bufferMs) {
+		console.log("🔄 [OIDC Auth] Cached token has expired");
+		return null;
+	}
 
-  console.log("✅ [OIDC Auth] Using cached token");
-  return cachedData.access_token;
+	console.log("✅ [OIDC Auth] Using cached token");
+	return cachedData.access_token;
 }
 
 function oidcPlugin(
-  options: OidcPluginOptions = getDefaultOidcPluginOptions()
+	options: OidcPluginOptions = getDefaultOidcPluginOptions(),
 ): Plugin {
-  return {
-    name: "vite-plugin-oidc-auth",
-    apply(_config, { command }) {
-      return command === "serve";
-    },
+	return {
+		name: "vite-plugin-oidc-auth",
+		apply(_config, { command }) {
+			return command === "serve";
+		},
 
-    config(config, { command }) {
-      if (command !== "serve") return;
+		config(config, { command }) {
+			if (command !== "serve") return;
 
-      if (!options.oidcOptions) {
-        try {
-          options.oidcOptions = getEnvOidcPluginOptions(options.envFilePath);
-        } catch (_error) {
-          console.warn(
-            "⚠️  [OIDC Auth] Plugin will be disabled due to configuration error"
-          );
-          return;
-        }
-      }
+			if (!options.oidcOptions) {
+				try {
+					options.oidcOptions = getEnvOidcPluginOptions(options.envFilePath);
+				} catch (_error) {
+					console.warn(
+						"⚠️  [OIDC Auth] Plugin will be disabled due to configuration error",
+					);
+					return;
+				}
+			}
 
-      console.log(
-        `⚙️  [OIDC Auth] Plugin initialized with auto-browser: ${
-          options.openBrowser ? "enabled" : "disabled"
-        }`
-      );
+			console.log(
+				`⚙️  [OIDC Auth] Plugin initialized with auto-browser: ${
+					options.openBrowser ? "enabled" : "disabled"
+				}`,
+			);
 
-      if (!config.define) {
-        config.define = {};
-      }
-      config.define["import.meta.env.VITE_API_TOKEN"] = JSON.stringify(
-        process.env.VITE_API_TOKEN || null
-      );
-      return config;
-    },
+			if (!config.define) {
+				config.define = {};
+			}
+			config.define["import.meta.env.VITE_API_TOKEN"] = JSON.stringify(
+				process.env.VITE_API_TOKEN || null,
+			);
+			return config;
+		},
 
-    configureServer(devServer: ViteDevServer) {
-      if (!options.oidcOptions) {
-        console.warn(
-          "⚠️  [OIDC Auth] Plugin disabled due to missing configuration"
-        );
-        return;
-      }
+		configureServer(devServer: ViteDevServer) {
+			if (!options.oidcOptions) {
+				console.warn(
+					"⚠️  [OIDC Auth] Plugin disabled due to missing configuration",
+				);
+				return;
+			}
 
-      const server = devServer;
-      const cacheFile = options.cacheFile || ".oidc-cache.json";
+			const server = devServer;
+			const cacheFile = options.cacheFile || ".oidc-cache.json";
 
-      const cachedToken = validateCachedToken(cacheFile);
-      if (cachedToken) {
-        process.env.VITE_API_TOKEN = cachedToken;
-        if (server?.config.define) {
-          server.config.define["import.meta.env.VITE_API_TOKEN"] =
-            JSON.stringify(cachedToken);
-        }
-        console.log("🔑 [OIDC Auth] Using cached token:", cachedToken);
-        return;
-      }
+			const cachedToken = validateCachedToken(cacheFile);
+			if (cachedToken) {
+				process.env.VITE_API_TOKEN = cachedToken;
+				if (server?.config.define) {
+					server.config.define["import.meta.env.VITE_API_TOKEN"] =
+						JSON.stringify(cachedToken);
+				}
+				console.log("🔑 [OIDC Auth] Using cached token:", cachedToken);
+				return;
+			}
 
-      console.log(
-        "🔄 [OIDC Auth] No valid cached token found, starting SSO flow"
-      );
+			console.log(
+				"🔄 [OIDC Auth] No valid cached token found, starting SSO flow",
+			);
 
-      const { port, hostname } = new URL(
-        options.oidcOptions?.redirectUri || ""
-      );
+			const { port, hostname } = new URL(
+				options.oidcOptions?.redirectUri || "",
+			);
 
-      const codeVerifier = client.randomPKCECodeVerifier();
-      const expectedState = client.randomState();
-      const expectedNonce = client.randomNonce();
-      let codeChallenge: string;
-      let config: client.Configuration;
+			const codeVerifier = client.randomPKCECodeVerifier();
+			const expectedState = client.randomState();
+			const expectedNonce = client.randomNonce();
+			let codeChallenge: string;
+			let config: client.Configuration;
 
-      const tempHttpServer = createServer(
-        async (req: IncomingMessage, res: ServerResponse) => {
-          if (!req.url) {
-            res.writeHead(400).end("Bad Request");
-            return;
-          }
+			const tempHttpServer = createServer(
+				async (req: IncomingMessage, res: ServerResponse) => {
+					if (!req.url) {
+						res.writeHead(400).end("Bad Request");
+						return;
+					}
 
-          const currentUrl = new URL(req.url, `http://${req.headers.host}`);
+					const currentUrl = new URL(req.url, `http://${req.headers.host}`);
 
-          if (currentUrl.searchParams.has("code")) {
-            try {
-              const tokens = await client.authorizationCodeGrant(
-                config,
-                currentUrl,
-                {
-                  pkceCodeVerifier: codeVerifier,
-                  expectedState,
-                  expectedNonce,
-                }
-              );
+					if (currentUrl.searchParams.has("code")) {
+						try {
+							const tokens = await client.authorizationCodeGrant(
+								config,
+								currentUrl,
+								{
+									pkceCodeVerifier: codeVerifier,
+									expectedState,
+									expectedNonce,
+								},
+							);
 
-              process.env.VITE_API_TOKEN = tokens.access_token;
+							process.env.VITE_API_TOKEN = tokens.access_token;
 
-              if (server?.config.define) {
-                server.config.define["import.meta.env.VITE_API_TOKEN"] =
-                  JSON.stringify(tokens.access_token);
-              }
+							if (server?.config.define) {
+								server.config.define["import.meta.env.VITE_API_TOKEN"] =
+									JSON.stringify(tokens.access_token);
+							}
 
-              const expired_at = Date.now() + (tokens.expires_in || 0) * 1000;
+							const expired_at = Date.now() + (tokens.expires_in || 0) * 1000;
 
-              const tokenData: CachedTokenData = {
-                access_token: tokens.access_token,
-                refresh_token: tokens.refresh_token,
-                expires_at: expired_at,
-                token_type: tokens.token_type,
-              };
-              writeCachedToken(cacheFile, tokenData);
+							const tokenData: CachedTokenData = {
+								access_token: tokens.access_token,
+								refresh_token: tokens.refresh_token,
+								expires_at: expired_at,
+								token_type: tokens.token_type,
+							};
+							writeCachedToken(cacheFile, tokenData);
 
-              console.log("✅ [OIDC Auth] Access token obtained successfully!");
-              console.log("🔑 [OIDC Auth] Token:", tokens.access_token);
-              console.log("💾 [OIDC Auth] Token cached for future use");
-              res.writeHead(200, { "Content-Type": "text/html" });
-              res.end(createSuccessPage());
-            } catch (error) {
-              console.error(
-                "❌ [OIDC Auth] Error obtaining access token:",
-                error
-              );
-              res.writeHead(500, { "Content-Type": "text/html" });
-              res.end(createErrorPage());
-            } finally {
-              if (serverTimeout) {
-                clearTimeout(serverTimeout);
-              }
-              tempHttpServer.close();
-            }
-          } else {
-            res
-              .writeHead(400)
-              .end("Bad Request: No authorization code received");
-          }
-        }
-      );
+							console.log("✅ [OIDC Auth] Access token obtained successfully!");
+							console.log("🔑 [OIDC Auth] Token:", tokens.access_token);
+							console.log("💾 [OIDC Auth] Token cached for future use");
+							res.writeHead(200, { "Content-Type": "text/html" });
+							res.end(createSuccessPage());
+						} catch (error) {
+							console.error(
+								"❌ [OIDC Auth] Error obtaining access token:",
+								error,
+							);
+							res.writeHead(500, { "Content-Type": "text/html" });
+							res.end(createErrorPage());
+						} finally {
+							if (serverTimeout) {
+								clearTimeout(serverTimeout);
+							}
+							tempHttpServer.close();
+						}
+					} else {
+						res
+							.writeHead(400)
+							.end("Bad Request: No authorization code received");
+					}
+				},
+			);
 
-      let serverTimeout: NodeJS.Timeout | null = null;
+			let serverTimeout: NodeJS.Timeout | null = null;
 
-      tempHttpServer.listen(parseInt(port, 10), hostname, async () => {
-        console.log(
-          `🚀 [OIDC Auth] Starting authentication server on ${hostname}:${port}`
-        );
+			tempHttpServer.listen(parseInt(port, 10), hostname, async () => {
+				console.log(
+					`🚀 [OIDC Auth] Starting authentication server on ${hostname}:${port}`,
+				);
 
-        const timeoutSeconds = options.serverTimeout || 30;
-        serverTimeout = setTimeout(() => {
-          console.log(
-            `⏱️  [OIDC Auth] Server timeout reached (${timeoutSeconds}s). Closing authentication server.`
-          );
-          console.log(
-            "❌ [OIDC Auth] Authentication was not completed within the timeout period"
-          );
-          tempHttpServer.close();
-        }, timeoutSeconds * 1000);
+				const timeoutSeconds = options.serverTimeout || 30;
+				serverTimeout = setTimeout(() => {
+					console.log(
+						`⏱️  [OIDC Auth] Server timeout reached (${timeoutSeconds}s). Closing authentication server.`,
+					);
+					console.log(
+						"❌ [OIDC Auth] Authentication was not completed within the timeout period",
+					);
+					tempHttpServer.close();
+				}, timeoutSeconds * 1000);
 
-        try {
-          const discoveryUrl = new URL(options.oidcOptions?.discoveryUrl || "");
-          const issuerPath = discoveryUrl.pathname.endsWith(
-            "/.well-known/openid-configuration"
-          )
-            ? discoveryUrl.pathname.replace(
-                "/.well-known/openid-configuration",
-                ""
-              )
-            : discoveryUrl.pathname;
-          const issuerUrl = new URL(discoveryUrl.origin + issuerPath);
+				try {
+					const discoveryUrl = new URL(options.oidcOptions?.discoveryUrl || "");
+					const issuerPath = discoveryUrl.pathname.endsWith(
+						"/.well-known/openid-configuration",
+					)
+						? discoveryUrl.pathname.replace(
+								"/.well-known/openid-configuration",
+								"",
+							)
+						: discoveryUrl.pathname;
+					const issuerUrl = new URL(discoveryUrl.origin + issuerPath);
 
-          console.log(
-            `🔍 [OIDC Auth] Discovering OIDC configuration from: ${issuerUrl.href}`
-          );
+					console.log(
+						`🔍 [OIDC Auth] Discovering OIDC configuration from: ${issuerUrl.href}`,
+					);
 
-          config = await client.discovery(
-            issuerUrl,
-            options.oidcOptions?.clientId || "",
-            options.oidcOptions?.clientSecret || ""
-          );
+					config = await client.discovery(
+						issuerUrl,
+						options.oidcOptions?.clientId || "",
+						options.oidcOptions?.clientSecret || "",
+					);
 
-          codeChallenge = await client.calculatePKCECodeChallenge(codeVerifier);
+					codeChallenge = await client.calculatePKCECodeChallenge(codeVerifier);
 
-          const authorizationUrl = client.buildAuthorizationUrl(config, {
-            redirect_uri: options.oidcOptions?.redirectUri || "",
-            scope: options.oidcOptions?.scope || "",
-            code_challenge: codeChallenge,
-            code_challenge_method: "S256",
-            state: expectedState,
-            nonce: expectedNonce,
-          });
+					const authorizationUrl = client.buildAuthorizationUrl(config, {
+						redirect_uri: options.oidcOptions?.redirectUri || "",
+						scope: options.oidcOptions?.scope || "",
+						code_challenge: codeChallenge,
+						code_challenge_method: "S256",
+						state: expectedState,
+						nonce: expectedNonce,
+					});
 
-          console.log(
-            `🔒 [OIDC Auth] Authentication URL generated successfully`
-          );
-          console.log(`🌐 [OIDC Auth] ${authorizationUrl.href}`);
-          console.log(
-            `⏰ [OIDC Auth] Server will timeout in ${timeoutSeconds} seconds`
-          );
+					console.log(
+						`🔒 [OIDC Auth] Authentication URL generated successfully`,
+					);
+					console.log(`🌐 [OIDC Auth] ${authorizationUrl.href}`);
+					console.log(
+						`⏰ [OIDC Auth] Server will timeout in ${timeoutSeconds} seconds`,
+					);
 
-          if (options.openBrowser) {
-            console.log(`🚀 [OIDC Auth] Opening browser automatically...`);
-            openBrowser(authorizationUrl.href);
-          } else {
-            console.log(
-              `📋 [OIDC Auth] Please open the above URL in your browser to authenticate`
-            );
-          }
-        } catch (error) {
-          console.error("❌ [OIDC Auth] Error setting up OIDC client:", error);
-          if (serverTimeout) {
-            clearTimeout(serverTimeout);
-          }
-          tempHttpServer.close();
-        }
-      });
-    },
-  };
+					if (options.openBrowser) {
+						console.log(`🚀 [OIDC Auth] Opening browser automatically...`);
+						openBrowser(authorizationUrl.href);
+					} else {
+						console.log(
+							`📋 [OIDC Auth] Please open the above URL in your browser to authenticate`,
+						);
+					}
+				} catch (error) {
+					console.error("❌ [OIDC Auth] Error setting up OIDC client:", error);
+					if (serverTimeout) {
+						clearTimeout(serverTimeout);
+					}
+					tempHttpServer.close();
+				}
+			});
+		},
+	};
 }
 
 export default oidcPlugin;

--- a/packages/lib/types.ts
+++ b/packages/lib/types.ts
@@ -10,13 +10,13 @@ export type OidcPluginOptions = {
 	oidcOptions?: OidcOptions;
 	openBrowser?: boolean;
 	envFilePath?: string;
-  cacheFile?: string;
-  serverTimeout?: number; // in seconds
+	cacheFile?: string;
+	serverTimeout?: number; // in seconds
 };
 
 export type CachedTokenData = {
-  access_token: string;
-  refresh_token?: string;
-  expires_at: number;
-  token_type?: string;
-}
+	access_token: string;
+	refresh_token?: string;
+	expires_at: number;
+	token_type?: string;
+};

--- a/packages/lib/utils.ts
+++ b/packages/lib/utils.ts
@@ -1,59 +1,59 @@
 import { exec } from "node:child_process";
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { CachedTokenData } from "./types";
+import type { CachedTokenData } from "./types";
 
 export function openBrowser(url: string): void {
-  const platform = process.platform;
-  let command: string;
+	const platform = process.platform;
+	let command: string;
 
-  switch (platform) {
-    case "darwin":
-      command = `open "${url}"`;
-      break;
-    case "win32":
-      command = `start "" "${url}"`;
-      break;
-    default:
-      command = `xdg-open "${url}"`;
-  }
+	switch (platform) {
+		case "darwin":
+			command = `open "${url}"`;
+			break;
+		case "win32":
+			command = `start "" "${url}"`;
+			break;
+		default:
+			command = `xdg-open "${url}"`;
+	}
 
-  exec(command, (error) => {
-    if (error) {
-      console.warn(
-        `⚠️  [OIDC Auth] Failed to open browser automatically: ${error.message}`
-      );
-    }
-  });
+	exec(command, (error) => {
+		if (error) {
+			console.warn(
+				`⚠️  [OIDC Auth] Failed to open browser automatically: ${error.message}`,
+			);
+		}
+	});
 }
 
 function getCacheFilePath(cacheFile: string): string {
-  return path.resolve(process.cwd(), cacheFile);
+	return path.resolve(process.cwd(), cacheFile);
 }
 
 export function readCachedToken(cacheFile: string): CachedTokenData | null {
-  try {
-    const cacheFilePath = getCacheFilePath(cacheFile);
-    if (!fs.existsSync(cacheFilePath)) {
-      return null;
-    }
+	try {
+		const cacheFilePath = getCacheFilePath(cacheFile);
+		if (!fs.existsSync(cacheFilePath)) {
+			return null;
+		}
 
-    const cachedData = fs.readFileSync(cacheFilePath, "utf8");
-    return JSON.parse(cachedData) as CachedTokenData;
-  } catch (error) {
-    console.warn("⚠️  [OIDC Auth] Failed to read cached token:", error);
-    return null;
-  }
+		const cachedData = fs.readFileSync(cacheFilePath, "utf8");
+		return JSON.parse(cachedData) as CachedTokenData;
+	} catch (error) {
+		console.warn("⚠️  [OIDC Auth] Failed to read cached token:", error);
+		return null;
+	}
 }
 
 export function writeCachedToken(
-  cacheFile: string,
-  tokenData: CachedTokenData
+	cacheFile: string,
+	tokenData: CachedTokenData,
 ): void {
-  try {
-    const cacheFilePath = getCacheFilePath(cacheFile);
-    fs.writeFileSync(cacheFilePath, JSON.stringify(tokenData, null, 2));
-  } catch (error) {
-    console.warn("⚠️  [OIDC Auth] Failed to write cached token:", error);
-  }
+	try {
+		const cacheFilePath = getCacheFilePath(cacheFile);
+		fs.writeFileSync(cacheFilePath, JSON.stringify(tokenData, null, 2));
+	} catch (error) {
+		console.warn("⚠️  [OIDC Auth] Failed to write cached token:", error);
+	}
 }

--- a/scripts/verify-release-tag.mjs
+++ b/scripts/verify-release-tag.mjs
@@ -1,0 +1,30 @@
+import { readFile } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const args = process.argv.slice(2).filter((arg) => arg !== "--");
+const rawTag = args[0] ?? process.env.GITHUB_REF_NAME ?? "";
+const tag = rawTag.replace(/^refs\/tags\//, "");
+
+if (!tag) {
+	throw new Error(
+		"Missing release tag. Pass a tag argument or set GITHUB_REF_NAME.",
+	);
+}
+
+const packageJson = JSON.parse(
+	await readFile(join(repoRoot, "package.json"), "utf8"),
+);
+if (typeof packageJson.version !== "string" || !packageJson.version) {
+	throw new Error("package.json does not declare a version.");
+}
+
+const expectedTag = `v${packageJson.version}`;
+if (tag !== expectedTag) {
+	throw new Error(
+		`Release tag ${tag} does not match package version ${packageJson.version}. Expected ${expectedTag}.`,
+	);
+}
+
+console.log(`Release tag ${tag} matches package version ${packageJson.version}.`);


### PR DESCRIPTION
## Summary
- add a tag-triggered release workflow modeled on Nerve's trusted publishing setup
- validate release tags against the package version before checking, building, and packing
- publish stable and prerelease packages to npm with provenance, then create an idempotent GitHub Release
- add non-mutating Biome and TypeScript checks and fix existing formatting to satisfy the release gate

## Validation
- `pnpm install --frozen-lockfile`
- `pnpm check`
- `pnpm build`
- release tag success and mismatch checks
- `npm pack --dry-run`

## Follow-up
Configure npm trusted publishing for repository `ThilinaTLM/vite-plugin-oidc-auth` and workflow `release.yml` before pushing the next release tag.